### PR TITLE
Feature/76 update panthalassa

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,76 @@
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.0.0.tgz",
       "integrity": "sha1-M9HbtlmiO4H4fwSHYrNaRGFyrdM="
     },
+    "BITNATION-Pangea-libs": {
+      "version": "git+https://github.com/Bit-Nation/BITNATION-Pangea-libs.git#81238f3d5f7a34b0b909713516f7d68b9e9f301f",
+      "requires": {
+        "assert": "1.4.1",
+        "bip39": "2.5.0",
+        "crypto-js": "3.1.9-1",
+        "es6-promise": "4.2.2",
+        "ethereumjs-tx": "1.3.3",
+        "ethereumjs-util": "5.1.3",
+        "eventemitter3": "2.0.3",
+        "flow-bin": "0.57.3",
+        "realm": "2.1.1",
+        "web3": "git+https://github.com/ethereum/web3.js.git#89b9cb9e046edf22ecac706f5d5983c6d764f84d",
+        "web3-provider-engine": "13.5.0"
+      },
+      "dependencies": {
+        "web3": {
+          "version": "git+https://github.com/ethereum/web3.js.git#89b9cb9e046edf22ecac706f5d5983c6d764f84d",
+          "requires": {
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+            "crypto-js": "3.1.8",
+            "utf8": "2.1.2",
+            "xhr2": "0.1.4",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "crypto-js": {
+              "version": "3.1.8",
+              "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
+              "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
+            }
+          }
+        }
+      }
+    },
+    "BITNATION-Pangea-utils": {
+      "version": "git+https://github.com/Bit-Nation/BITNATION-Pangea-libs.git#368dd06818a9a8a5932b7d9b762e96af20110b1c",
+      "requires": {
+        "assert": "1.4.1",
+        "bip39": "2.5.0",
+        "crypto-js": "3.1.9-1",
+        "es6-promise": "4.2.2",
+        "ethereumjs-tx": "1.3.3",
+        "ethereumjs-util": "5.1.3",
+        "eventemitter3": "2.0.3",
+        "flow-bin": "0.57.3",
+        "realm": "2.1.1",
+        "web3": "git+https://github.com/ethereum/web3.js.git#89b9cb9e046edf22ecac706f5d5983c6d764f84d",
+        "web3-provider-engine": "13.5.0"
+      },
+      "dependencies": {
+        "web3": {
+          "version": "git+https://github.com/ethereum/web3.js.git#89b9cb9e046edf22ecac706f5d5983c6d764f84d",
+          "requires": {
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+            "crypto-js": "3.1.8",
+            "utf8": "2.1.2",
+            "xhr2": "0.1.4",
+            "xmlhttprequest": "1.8.0"
+          },
+          "dependencies": {
+            "crypto-js": {
+              "version": "3.1.8",
+              "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
+              "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
+            }
+          }
+        }
+      }
+    },
     "BITNATION-Panthalassa": {
       "version": "git+https://github.com/Bit-Nation/BITNATION-Pangea-libs.git#8f664cbf42c44be020ca95b3de643ebff703959a",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "docs": "node_modules/.bin/documentation build src/services/container.js -f md > docs/main.md"
   },
   "dependencies": {
+    "BITNATION-Pangea-libs": "git+https://github.com/Bit-Nation/BITNATION-Pangea-libs.git#81238f3d5f7a34b0b909713516f7d68b9e9f301f",
+    "BITNATION-Pangea-utils": "git+https://github.com/Bit-Nation/BITNATION-Pangea-libs.git#368dd06818a9a8a5932b7d9b762e96af20110b1c",
     "BITNATION-Panthalassa": "git+https://github.com/Bit-Nation/BITNATION-Pangea-libs.git#8f664cbf42c44be020ca95b3de643ebff703959a",
     "assert": "^1.4.1",
     "awilix": "^3.0.1",

--- a/src/services/container.js
+++ b/src/services/container.js
@@ -1,38 +1,20 @@
 //@flow
 
-import db from 'BITNATION-Panthalassa/src/database/db';
+import pangeaLibsFactory from 'BITNATION-Pangea-libs'
 import secureStorage from './panthalassa/secureStorage';
-import ethUtils from 'BITNATION-Panthalassa/src/ethereum/utils';
-import web3 from 'BITNATION-Panthalassa/src/ethereum/web3';
 import osDeps from './panthalassa/osDependencies';
 import ethDaemon from './panthalassa/ethDaemon';
-import wallet from 'BITNATION-Panthalassa/src/ethereum/wallet';
-import profile from 'BITNATION-Panthalassa/src/profile/profile';
+const EventEmitter = require('eventemitter3');
 
-async function createContainer() {
-  const EventEmitter = require('eventemitter3');
+const DB_PATH = 'pangea';
 
-  const DB_PATH = 'panthalassa';
+const ee = new EventEmitter();
 
-  const ee = new EventEmitter();
-  const dbInstance = db(DB_PATH);
-  const ethUtilsInstance = ethUtils(secureStorage, ee, osDeps);
-  const ethWeb3Instance = await web3(ethDaemon, ee, ethUtilsInstance);
-  const ethWallet = wallet(ethUtilsInstance, ethWeb3Instance, dbInstance);
-  const profileInstance = profile(dbInstance, ethUtilsInstance);
-
-  return {
-    eventEmitter: ee,
-    panthalassa: {
-      database: dbInstance,
-      ethereum: {
-        utils: ethUtilsInstance,
-        web3: ethWeb3Instance,
-        wallet: ethWallet,
-      },
-      profile: profileInstance,
-    },
-  };
-}
-
-export default createContainer();
+export default pangeaLibsFactory(
+    secureStorage,
+    DB_PATH,
+    ethDaemon,
+    osDeps,
+    ee,
+    false
+);


### PR DESCRIPTION
#### Changes


* Changed pangea lib's version (panthalassa was renamed to pangea lib's)
* updated service container

#### Verification


* CI should pass

#### MIGRATION
The imported service container is now a promise. So make sure to use `then` and `catch`. 
The promise will resolve with the following object: 

```js
{
eventEmitter: ee,
eth: {
utils: ethUtils,
wallet: wallet
},
profile: {
profile,
},
}
```

